### PR TITLE
Do not use regex for exact annotation name matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ ENV/
 *.swc
 *.json
 MANIFEST
+
+tmp/

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1894,22 +1894,23 @@ def get_annotations(x, remote_instance=None):
             'No annotations retrieved. Make sure that the skeleton IDs exist.')
 
 
-def filter_by_query(names: pd.Series[str], query: str, allow_partial: bool = False):
-    """_summary_
+def filter_by_query(names: pd.Series, query: str, allow_partial: bool = False) -> pd.Series:
+    """Get a logical index series into a series of strings based on a query.
 
     Parameters
     ----------
-    names : pd.Series[str]
+    names : pd.Series of str
         Dataframe column of strings to filter
     query : str
-        _description_
-    allow_partial : bool
-        _description_
+        Query string. leading "~" and "annotation:" will be ignored.
+        Leading "/" will mean the remainder is used as a regex.
+    allow_partial : bool, default False
+        For non-regex queries, whether to check that the query is an exact match or just contained in the name.
 
     Returns
     -------
-    _type_
-        _description_
+    pd.Series of bool
+        Which names match the given query
     """
     if query.startswith("annotation:"):
         logger.warning('Removing unexpected "annotation:" prefix from "%s"', query)
@@ -1930,6 +1931,7 @@ def filter_by_query(names: pd.Series[str], query: str, allow_partial: bool = Fal
     # If exact match
     else:
         filt = names.str == q
+
     return filt
 
 

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1915,13 +1915,10 @@ def filter_by_query(names: pd.Series, query: str, allow_partial: bool = False) -
     if not isinstance(names, pd.Series):
         names = pd.Series(names, dtype=str)
 
-    if query.startswith("annotation:"):
-        logger.warning('Removing unexpected "annotation:" prefix from "%s"', query)
-        query = query[11:]
-
-    if query.startswith('~'):
-        logger.warning('Removing "~" prefix (without negating) from "%s"', query)
-        query = query[1:]
+    for prefix in ["annotation:", "~"]:
+        if query.startswith(prefix):
+            logger.warning("Removing '%s' prefix from '%s'", prefix, query)
+            query = query[len(prefix):]
 
     q = query.strip()
     # use a regex

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1928,12 +1928,10 @@ def filter_by_query(names: pd.Series, query: str, allow_partial: bool = False) -
     if q.startswith("/"):
         re_str = q[1:]
         filt = names.str.match(re_str)
-    # If allow partial just use the raw string
-    elif allow_partial:
-        filt = names.str.contains(q)
-    # If exact match
     else:
-        filt = names.str == q
+        filt = names.str.contains(q, regex=False)
+        if not allow_partial:
+            filt = np.logical_and(filt, names.str.len() == len(q))
 
     return filt
 

--- a/pymaid/fetch.py
+++ b/pymaid/fetch.py
@@ -1912,6 +1912,9 @@ def filter_by_query(names: pd.Series, query: str, allow_partial: bool = False) -
     pd.Series of bool
         Which names match the given query
     """
+    if not isinstance(names, pd.Series):
+        names = pd.Series(names, dtype=str)
+
     if query.startswith("annotation:"):
         logger.warning('Removing unexpected "annotation:" prefix from "%s"', query)
         query = query[11:]

--- a/pymaid/tests/test_utils.py
+++ b/pymaid/tests/test_utils.py
@@ -15,7 +15,7 @@ def test_filter_by_query_exact(query):
 @pytest.mark.parametrize("query", ["ad", "~ad", "annotation:ad"])
 def test_filter_by_query_partial(query):
     out = filter_by_query(NAMES, query, allow_partial=True)
-    assert list(out) == [False, True, False, False, False]
+    assert list(out) == [False, True, False, False]
 
 
 @pytest.mark.parametrize("query", ["sp.*e", "~sp.*e", "annotation:sp.*e"])

--- a/pymaid/tests/test_utils.py
+++ b/pymaid/tests/test_utils.py
@@ -23,3 +23,15 @@ def test_filter_by_query_re(query):
     out = filter_by_query(NAMES, query)
     assert list(out) == [False, True, False, False]
 
+
+def test_filter_by_query_220(query):
+    """Issue #220: special characters break exact name matches
+
+    https://github.com/navis-org/pymaid/issues/220
+    """
+    out = filter_by_query(
+        pd.Series(["*potato", "*spade", "*orange", "*bears"]),
+        "*spade",
+    )
+    assert list(out) == [False, True, False, False]
+

--- a/pymaid/tests/test_utils.py
+++ b/pymaid/tests/test_utils.py
@@ -18,13 +18,13 @@ def test_filter_by_query_partial(query):
     assert list(out) == [False, True, False, False]
 
 
-@pytest.mark.parametrize("query", ["sp.*e", "~sp.*e", "annotation:sp.*e"])
+@pytest.mark.parametrize("query", ["/sp.*e", "~/sp.*e", "annotation:/sp.*e"])
 def test_filter_by_query_re(query):
     out = filter_by_query(NAMES, query)
     assert list(out) == [False, True, False, False]
 
 
-def test_filter_by_query_220(query):
+def test_filter_by_query_220():
     """Issue #220: special characters break exact name matches
 
     https://github.com/navis-org/pymaid/issues/220

--- a/pymaid/tests/test_utils.py
+++ b/pymaid/tests/test_utils.py
@@ -1,0 +1,25 @@
+from pymaid.fetch import filter_by_query
+import pandas as pd
+import pytest
+
+
+NAMES = pd.Series(["potato", "spade", "orange", "bears"])
+
+
+@pytest.mark.parametrize("query", ["spade", "~spade", "annotation:spade"])
+def test_filter_by_query_exact(query):
+    out = filter_by_query(NAMES, query)
+    assert list(out) == [False, True, False, False]
+
+
+@pytest.mark.parametrize("query", ["ad", "~ad", "annotation:ad"])
+def test_filter_by_query_partial(query):
+    out = filter_by_query(NAMES, query, allow_partial=True)
+    assert list(out) == [False, True, False, False, False]
+
+
+@pytest.mark.parametrize("query", ["sp.*e", "~sp.*e", "annotation:sp.*e"])
+def test_filter_by_query_re(query):
+    out = filter_by_query(NAMES, query)
+    assert list(out) == [False, True, False, False]
+


### PR DESCRIPTION
Caused problems for annotation names with re special characters. Includes tests. Resolves #220 