### PR TITLE
Annotation graph fixes, logging normalisation

### DIFF
--- a/pymaid/__init__.py
+++ b/pymaid/__init__.py
@@ -3,7 +3,7 @@ __version_vector__ = (2, 2, 1)
 
 from . import config
 
-logger = config.logger
+logger = config.get_logger(__name__)
 
 # Flatten namespace by importing contents of all modules of pymaid
 from .fetch import *

--- a/pymaid/cache.py
+++ b/pymaid/cache.py
@@ -26,7 +26,7 @@ from collections import OrderedDict
 from . import utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 class Cache(OrderedDict):

--- a/pymaid/client.py
+++ b/pymaid/client.py
@@ -33,7 +33,7 @@ except BaseException:
 __all__ = sorted(['CatmaidInstance', 'connect_catmaid'])
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def load_env(**kwargs):

--- a/pymaid/cluster.py
+++ b/pymaid/cluster.py
@@ -27,7 +27,7 @@ from concurrent.futures import ThreadPoolExecutor
 from . import fetch, core, utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['cluster_by_connectivity', 'cluster_by_synapse_placement',
                   'cluster_xyz', 'ClustResults'])

--- a/pymaid/config.py
+++ b/pymaid/config.py
@@ -12,18 +12,26 @@
 #    GNU General Public License for more details.
 
 import logging
+import os
 
 import numpy as np
 
 logger = logging.getLogger('pymaid')
-logger.setLevel(logging.INFO)
-if len(logger.handlers) == 0:
-    sh = logging.StreamHandler()
-    sh.setLevel(logging.DEBUG)
-    # Create formatter and add it to the handlers
-    formatter = logging.Formatter('%(levelname)-5s : %(message)s (%(name)s)')
-    sh.setFormatter(formatter)
-    logger.addHandler(sh)
+
+def default_logging():
+    logger.setLevel(logging.INFO)
+    if len(logger.handlers) == 0:
+        sh = logging.StreamHandler()
+        sh.setLevel(logging.DEBUG)
+        # Create formatter and add it to the handlers
+        formatter = logging.Formatter('%(levelname)-5s : %(message)s (%(name)s)')
+        sh.setFormatter(formatter)
+        logger.addHandler(sh)
+
+
+if os.environ.get("NAVIS_SKIP_LOG_SETUP", "").lower() != "true":
+    default_logging()
+
 
 # Default settings for progress bars
 pbar_hide = False

--- a/pymaid/config.py
+++ b/pymaid/config.py
@@ -29,8 +29,16 @@ def default_logging():
         logger.addHandler(sh)
 
 
-if os.environ.get("NAVIS_SKIP_LOG_SETUP", "").lower() != "true":
+NAVIS_SKIP_LOG_SETUP = os.environ.get("NAVIS_SKIP_LOG_SETUP", "").lower() == "true"
+
+if not NAVIS_SKIP_LOG_SETUP:
     default_logging()
+
+
+def get_logger(module_name: str):
+    if NAVIS_SKIP_LOG_SETUP:
+        return logging.getLogger(module_name)
+    return logger
 
 
 # Default settings for progress bars

--- a/pymaid/connectivity.py
+++ b/pymaid/connectivity.py
@@ -27,7 +27,7 @@ from navis import graph_utils, intersect
 from . import fetch, core, utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['filter_connectivity', 'cable_overlap',
                   'predict_connectivity', 'adjacency_matrix', 'group_matrix',

--- a/pymaid/core.py
+++ b/pymaid/core.py
@@ -83,7 +83,7 @@ except ImportError:
 __all__ = ['CatmaidNeuron', 'CatmaidNeuronList', 'Dotprops', 'Volume']
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 def inject_connection(func):

--- a/pymaid/fetch/__init__.py
+++ b/pymaid/fetch/__init__.py
@@ -1899,6 +1899,48 @@ def get_annotations(x, remote_instance=None):
             'No annotations retrieved. Make sure that the skeleton IDs exist.')
 
 
+def _entities_to_ann_graph(data, annotations_by_id=False, skeletons_by_id=True):
+    ann_ref = "id" if annotations_by_id else "name"
+    skel_ref = "id" if skeletons_by_id else "name"
+
+    g = nx.DiGraph()
+
+    for e in data["entities"]:
+        is_meta_ann = False
+
+        if e.get("type") == "neuron":
+            skids = e.get("skeleton_ids") or []
+            if len(skids) != 1:
+                logger.warning("Neuron with id %s is modelled by %s skeletons, ignoring", e["id"], len(skids))
+                continue
+            node_data = {
+                "name": e["name"],
+                "neuron_id": e["id"],
+                "is_skeleton": True,
+                "id": skids[0],
+            }
+            node_id = node_data[skel_ref]
+        else:  # is an annotation
+            node_data = {
+                "is_skeleton": False,
+                "id": e["id"],
+                "name": e["name"],
+            }
+            node_id = node_data[ann_ref]
+            is_meta_ann = True
+
+        for ann in e.get("annotations", []):
+            g.add_edge(
+                ann[ann_ref],
+                node_id,
+                is_meta_annotation=is_meta_ann,
+            )
+
+        g.nodes[node_id].update(**node_data)
+
+    return g
+
+
 @cache.undo_on_error
 def get_annotation_graph(annotations_by_id=False, skeletons_by_id=True, remote_instance=None) -> nx.DiGraph:
     """Get a networkx DiGraph of (meta)annotations and skeletons.
@@ -1943,44 +1985,7 @@ def get_annotation_graph(annotations_by_id=False, skeletons_by_id=True, remote_i
     }
     data = remote_instance.fetch(query_url, post)
 
-    ann_ref = "id" if annotations_by_id else "name"
-    skel_ref = "id" if skeletons_by_id else "name"
-
-    g = nx.DiGraph()
-    for e in data["entities"]:
-        is_meta_ann = False
-
-        if e.get("type") == "neuron":
-            skids = e.get("skeleton_ids") or []
-            if len(skids) != 1:
-                logger.warning("Neuron with id %s is modelled by %s skeletons, ignoring", e["id"], len(skids))
-                continue
-            node_data = {
-                "name": e["name"],
-                "neuron_id": e["id"],
-                "is_skeleton": True,
-                "id": skids[0],
-            }
-            node_id = node_data[skel_ref]
-        else:  # is an annotation
-            node_data = {
-                "is_skeleton": False,
-                "id": e["id"],
-                "name": e["name"],
-            }
-            node_id = node_data[ann_ref]
-            is_meta_ann = True
-
-        g.add_node(node_id, **node_data)
-
-        for ann in e.get("annotations", []):
-            g.add_edge(
-                ann[ann_ref],
-                node_id,
-                is_meta_annotation=is_meta_ann,
-            )
-
-    return g
+    return _entities_to_ann_graph(data, annotations_by_id, skeletons_by_id)
 
 
 def filter_by_query(names: pd.Series, query: str, allow_partial: bool = False) -> pd.Series:

--- a/pymaid/fetch/__init__.py
+++ b/pymaid/fetch/__init__.py
@@ -1929,6 +1929,11 @@ def _entities_to_ann_graph(data, annotations_by_id=False, skeletons_by_id=True):
             node_id = node_data[ann_ref]
             is_meta_ann = True
 
+        anns = e.get("annotations", [])
+        if not anns:
+            g.add_node(node_id, **node_data)
+            continue
+
         for ann in e.get("annotations", []):
             g.add_edge(
                 ann[ann_ref],

--- a/pymaid/fetch/__init__.py
+++ b/pymaid/fetch/__init__.py
@@ -92,7 +92,7 @@ __all__ = ['get_annotation_details', 'get_annotation_id',
     ]
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 @cache.undo_on_error

--- a/pymaid/morpho.py
+++ b/pymaid/morpho.py
@@ -25,7 +25,7 @@ from navis import graph_utils, graph
 from . import fetch, core, utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = sorted(['arbor_confidence', 'remove_tagged_branches', 'time_machine',
                   'union_neurons', 'prune_by_length'])

--- a/pymaid/tiles.py
+++ b/pymaid/tiles.py
@@ -26,7 +26,7 @@ from requests_futures.sessions import FuturesSession
 from . import fetch, core, utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 try:
     import imageio

--- a/pymaid/upload.py
+++ b/pymaid/upload.py
@@ -49,7 +49,7 @@ __all__ = sorted(['add_annotations', 'remove_annotations',
                   'delete_volume', 'set_nodes_reviewed'])
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 
 @cache.never_cache

--- a/pymaid/user_stats.py
+++ b/pymaid/user_stats.py
@@ -62,7 +62,7 @@ import numpy as np
 from . import core, fetch, utils, config
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['get_user_contributions', 'get_time_invested', 'get_user_actions',
            'get_team_contributions', 'get_user_stats']

--- a/pymaid/utils.py
+++ b/pymaid/utils.py
@@ -33,7 +33,7 @@ with warnings.catch_warnings():
 from . import core, fetch, config, client
 
 # Set up logging
-logger = config.logger
+logger = config.get_logger(__name__)
 
 __all__ = ['set_loggers', 'set_pbars', 'eval_skids', 'clear_cache', 'shorten_name']
 


### PR DESCRIPTION
A couple of fixes/ improvements to the annotation graph fetcher, and allows pymaid to respect the NAVIS_SKIP_LOG_SETUP environment variable.

The recommendation for loggers is to use `logging.getLogger(__name__)` so that users can see and control where logs are coming from. Pymaid now does this if NAVIS_SKIP... is set, but defaults to the current look otherwise. New uses of logging should use `logger = config.get_logger(__name__)` rather than `logger = config.logger`. I intend to upstream this pattern to navis too.