### PR TITLE
Use CATMAID stack info to create xarray.DataArrays

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -179,9 +179,9 @@ Functions to fetch information about the image stacks CATMAID knows about.
 .. autosummary::
     :toctree: generated/
 
-    pymaid.fetch.stacks.get_stacks
-    pymaid.fetch.stacks.get_stack_info
-    pymaid.fetch.stacks.get_mirror_info
+    pymaid.get_stacks
+    pymaid.get_stack_info
+    pymaid.get_mirror_info
 
 Image data (tiles)
 ------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -172,6 +172,17 @@ Functions for reconstruction samplers:
     pymaid.get_sampler_domains
     pymaid.get_sampler_counts
 
+Image metadata
+--------------
+Functions to fetch information about the image stacks CATMAID knows about.
+
+.. autosummary::
+    :toctree: generated/
+
+    pymaid.fetch.stacks.get_stacks
+    pymaid.fetch.stacks.get_stack_info
+    pymaid.fetch.stacks.get_mirror_info
+
 Image data (tiles)
 ------------------
 Functions to fetch and process image data. Note that this is not imported at

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -183,19 +183,22 @@ Functions to fetch information about the image stacks CATMAID knows about.
     pymaid.get_stack_info
     pymaid.get_mirror_info
 
-Image data (tiles)
+Image data (tiles and N5 volumes)
 ------------------
 Functions to fetch and process image data. Note that this is not imported at
 top level but has to be imported explicitly::
 
   >>> from pymaid import tiles
   >>> help(tiles.crop_neuron)
+  >>> from pymaid.stack import Stack
+  >>> help(Stack)
 
 .. autosummary::
     :toctree: generated/
 
     pymaid.tiles.TileLoader
     pymaid.tiles.crop_neuron
+    pymaid.stack.Stack
 
 .. _api_misc:
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -15,11 +15,12 @@ What's new?
      - BREAKING: Drop python 3.7 support.
      - - :class:`pymaid.neuron_label.NeuronLabeller` added for labelling neurons
          like in the CATMAID frontend.
+       - :func:`pymaid.get_stacks`, :func:`pymaid.get_stack_info`, :func:`pymaid.get_mirror_info` functions for getting information about image data
+       - :class:`pymaid.stack.Stack` class for accessing N5 and JPEG tile image data as a :class:`xarray.DataArray`
    * - 2.4.0
      - 27/05/23
      - - :func:`pymaid.get_annotation_graph` deprecated in favour of the new
          :func:`pymaid.get_entity_graph`.
-       - :func:`pymaid.get_stacks`, :func:`pymaid.get_stack_info`, :func:`pymaid.get_mirror_info` functions for getting information about image data
    * - 2.1.0
      - 04/04/22
      - With this release we mainly follow some renamed functions in ``navis`` but

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -19,6 +19,7 @@ What's new?
      - 27/05/23
      - - :func:`pymaid.get_annotation_graph` deprecated in favour of the new
          :func:`pymaid.get_entity_graph`.
+       - :func:`pymaid.get_stacks`, :func:`pymaid.get_stack_info`, :func:`pymaid.get_mirror_info` functions for getting information about image data
    * - 2.1.0
      - 04/04/22
      - With this release we mainly follow some renamed functions in ``navis`` but

--- a/pymaid/fetch/__init__.py
+++ b/pymaid/fetch/__init__.py
@@ -57,6 +57,7 @@ from navis import in_volume
 from .landmarks import get_landmarks, get_landmark_groups
 from .skeletons import get_skeleton_ids
 from .annotations import get_annotation_graph, get_entity_graph, get_annotation_id
+from .stack import get_stacks, get_stack_info, get_mirror_info
 
 
 __all__ = ['get_annotation_details', 'get_annotation_id',
@@ -93,6 +94,7 @@ __all__ = ['get_annotation_details', 'get_annotation_id',
                   'get_landmarks',
                   'get_landmark_groups',
                   'get_skeleton_ids',
+                  'get_stacks', 'get_stack_info', 'get_mirror_info',
     ]
 
 # Set up logging

--- a/pymaid/fetch/annotations.py
+++ b/pymaid/fetch/annotations.py
@@ -391,7 +391,7 @@ def get_entity_graph(
 
     Neurons additionally have
 
-    - skeleton_ids: list[int]
+    - skeleton_ids: List[int]
 
     Skeletons additionally have
 

--- a/pymaid/fetch/stack.py
+++ b/pymaid/fetch/stack.py
@@ -1,0 +1,251 @@
+from typing import Any, Optional, Union, Literal, Sequence
+import numpy as np
+from ..utils import _eval_remote_instance
+from ..client import CatmaidInstance
+from enum import IntEnum
+from dataclasses import dataclass, asdict
+
+Dimension = Literal["x", "y", "z"]
+
+
+class Orientation(IntEnum):
+    XY = 0
+    # todo: check these
+    XZ = 1
+    ZY = 2
+
+    def __bool__(self) -> bool:
+        return True
+
+    def full_orientation(self, reverse=False) -> tuple[Dimension, Dimension, Dimension]:
+        out = [
+            ("x", "y", "z"),
+            ("x", "z", "y"),
+            ("z", "y", "x"),
+        ][self.value]
+        if reverse:
+            out = out[::-1]
+        return out
+
+    @classmethod
+    def from_dims(cls, dims: Sequence[Dimension]):
+        pair = (dims[0].lower(), dims[1].lower())
+        out = {
+            ("x", "y"): cls.XY,
+            ("x", "z"): cls.XZ,
+            ("z", "y"): cls.ZY,
+        }.get(pair)
+        if out is None:
+            raise ValueError(f"Unknown dimensions: {dims}")
+        return out
+
+
+@dataclass
+class StackSummary:
+    id: int
+    pid: int
+    title: str
+    comment: str
+
+
+def get_stacks(remote_instance: Optional[CatmaidInstance] = None) -> list[StackSummary]:
+    """Get summary of all stacks in the project.
+
+    Parameters
+    ----------
+    remote_instance : Optional[CatmaidInstance], optional
+        By default global instance.
+
+    Returns
+    -------
+    stacks
+        List of StackSummary objects.
+    """
+    cm = _eval_remote_instance(remote_instance)
+    url = cm.make_url(cm.project_id, "stacks")
+    return [StackSummary(**r) for r in cm.fetch(url)]
+
+
+@dataclass
+class MirrorInfo:
+    id: int
+    title: str
+    image_base: str
+    tile_width: int
+    tile_height: int
+    tile_source_type: int
+    file_extension: str
+    position: int
+
+    def to_jso(self):
+        return asdict(self)
+
+
+@dataclass
+class Color:
+    r: float
+    g: float
+    b: float
+    a: float
+
+
+@dataclass
+class StackInfo:
+    sid: int
+    pid: int
+    ptitle: str
+    stitle: str
+    downsample_factors: Optional[list[dict[Dimension, float]]]
+    num_zoom_levels: int
+    translation: dict[Dimension, float]
+    resolution: dict[Dimension, float]
+    dimension: dict[Dimension, int]
+    comment: str
+    description: str
+    metadata: Optional[str]
+    broken_slices: dict[int, int]
+    mirrors: list[MirrorInfo]
+    orientation: Orientation
+    attribution: str
+    canary_location: dict[Dimension, int]
+    placeholder_color: Color
+
+    @classmethod
+    def from_jso(cls, sinfo: dict[str, Any]):
+        sinfo["orientation"] = Orientation(sinfo["orientation"])
+        sinfo["placeholder_color"] = Color(**sinfo["placeholder_color"])
+        sinfo["mirrors"] = [MirrorInfo(**m) for m in sinfo["mirrors"]]
+        return StackInfo(**sinfo)
+
+    def to_jso(self):
+        return asdict(self)
+
+    def get_downsample(self, scale_level=0) -> dict[Dimension, float]:
+        """Get the downsample factors for a given scale level.
+
+        If the downsample factors are explicit in the stack info,
+        use that value.
+        Otherwise, use the CATMAID default:
+        scale by a factor of 2 per scale level in everything except the slicing dimension.
+        If number of scale levels is known,
+        ensure the scale level exists.
+
+        Parameters
+        ----------
+        scale_level : int, optional
+
+        Returns
+        -------
+        dict[Dimension, float]
+
+        Raises
+        ------
+        IndexError
+            If the scale level is known not to exist
+        """
+        if self.downsample_factors is not None:
+            return self.downsample_factors[scale_level]
+        if self.num_zoom_levels > 0 and scale_level >= self.num_zoom_levels:
+            raise IndexError("list index out of range")
+
+        first, second, slicing = self.orientation.full_orientation()
+        return {first: 2**scale_level, second: 2**scale_level, slicing: 1}
+
+    def get_coords(self, scale_level: int = 0) -> dict[Dimension, np.ndarray]:
+        dims = self.orientation.full_orientation()
+        dims = dims[::-1]
+
+        downsamples = self.get_downsample(scale_level)
+
+        out: dict[Dimension, np.ndarray] = dict()
+        for d in dims:
+            c = np.arange(self.dimension[d], dtype=float)
+            c *= self.resolution[d]
+            c *= downsamples[d]
+            c += self.translation[d]
+            out[d] = c
+        return out
+
+
+def get_stack_info(
+    stack: Union[int, str], remote_instance: Optional[CatmaidInstance] = None
+) -> StackInfo:
+    """Get information about an image stack.
+
+    Parameters
+    ----------
+    stack : Union[int, str]
+        Integer ID or string title of the stack.
+    remote_instance : Optional[CatmaidInstance], optional
+        By default global.
+
+    Returns
+    -------
+    StackInfo
+
+    Raises
+    ------
+    ValueError
+        If an unknown stack title is given.
+    """
+    cm = _eval_remote_instance(remote_instance)
+    if isinstance(stack, str):
+        stacks = get_stacks(cm)
+        for s in stacks:
+            if s.title == stack:
+                stack_id = s.id
+                break
+        else:
+            raise ValueError(f"No stack with title '{stack}'")
+    else:
+        stack_id = int(stack)
+
+    url = cm.make_url(cm.project_id, "stack", stack_id, "info")
+    sinfo = cm.fetch(url)
+    return StackInfo.from_jso(sinfo)
+
+
+def get_mirror_info(
+    stack: Union[int, str, StackInfo],
+    mirror: Union[int, str],
+    remote_instance: Optional[CatmaidInstance] = None,
+) -> MirrorInfo:
+    """Get information about a stack mirror.
+
+    Parameters
+    ----------
+    stack : Union[int, str, StackInfo]
+        Integer stack ID, string stack title,
+        or an existing StackInfo object (avoids server request).
+    mirror : Union[int, str]
+        Integer mirror ID, or string mirror title.
+    remote_instance : Optional[CatmaidInstance]
+        By default, global.
+
+    Returns
+    -------
+    MirrorInfo
+
+    Raises
+    ------
+    ValueError
+        No mirror matching given ID/ title.
+    """
+    if isinstance(stack, StackInfo):
+        stack_info = stack
+    else:
+        stack_info = get_stack_info(stack, remote_instance)
+
+    if isinstance(mirror, str):
+        key = "title"
+    else:
+        key = "id"
+        mirror = int(mirror)
+
+    for m in stack_info.mirrors:
+        if getattr(m, key) == mirror:
+            return m
+
+    raise ValueError(
+        f"No mirror for stack '{stack_info.stitle}' with {key} {repr(mirror)}"
+    )

--- a/pymaid/fetch/stack.py
+++ b/pymaid/fetch/stack.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union, Literal, Sequence
+from typing import Any, Optional, Union, Literal, Sequence, Tuple, Dict, List
 import numpy as np
 from ..utils import _eval_remote_instance
 from ..client import CatmaidInstance
@@ -17,7 +17,7 @@ class Orientation(IntEnum):
     def __bool__(self) -> bool:
         return True
 
-    def full_orientation(self, reverse=False) -> tuple[Dimension, Dimension, Dimension]:
+    def full_orientation(self, reverse=False) -> Tuple[Dimension, Dimension, Dimension]:
         out = [
             ("x", "y", "z"),
             ("x", "z", "y"),
@@ -48,7 +48,7 @@ class StackSummary:
     comment: str
 
 
-def get_stacks(remote_instance: Optional[CatmaidInstance] = None) -> list[StackSummary]:
+def get_stacks(remote_instance: Optional[CatmaidInstance] = None) -> List[StackSummary]:
     """Get summary of all stacks in the project.
 
     Parameters
@@ -95,23 +95,23 @@ class StackInfo:
     pid: int
     ptitle: str
     stitle: str
-    downsample_factors: Optional[list[dict[Dimension, float]]]
+    downsample_factors: Optional[List[Dict[Dimension, float]]]
     num_zoom_levels: int
-    translation: dict[Dimension, float]
-    resolution: dict[Dimension, float]
-    dimension: dict[Dimension, int]
+    translation: Dict[Dimension, float]
+    resolution: Dict[Dimension, float]
+    dimension: Dict[Dimension, int]
     comment: str
     description: str
     metadata: Optional[str]
-    broken_slices: dict[int, int]
-    mirrors: list[MirrorInfo]
+    broken_slices: Dict[int, int]
+    mirrors: List[MirrorInfo]
     orientation: Orientation
     attribution: str
-    canary_location: dict[Dimension, int]
+    canary_location: Dict[Dimension, int]
     placeholder_color: Color
 
     @classmethod
-    def from_jso(cls, sinfo: dict[str, Any]):
+    def from_jso(cls, sinfo: Dict[str, Any]):
         sinfo["orientation"] = Orientation(sinfo["orientation"])
         sinfo["placeholder_color"] = Color(**sinfo["placeholder_color"])
         sinfo["mirrors"] = [MirrorInfo(**m) for m in sinfo["mirrors"]]
@@ -120,7 +120,7 @@ class StackInfo:
     def to_jso(self):
         return asdict(self)
 
-    def get_downsample(self, scale_level=0) -> dict[Dimension, float]:
+    def get_downsample(self, scale_level=0) -> Dict[Dimension, float]:
         """Get the downsample factors for a given scale level.
 
         If the downsample factors are explicit in the stack info,
@@ -151,13 +151,13 @@ class StackInfo:
         first, second, slicing = self.orientation.full_orientation()
         return {first: 2**scale_level, second: 2**scale_level, slicing: 1}
 
-    def get_coords(self, scale_level: int = 0) -> dict[Dimension, np.ndarray]:
+    def get_coords(self, scale_level: int = 0) -> Dict[Dimension, np.ndarray]:
         dims = self.orientation.full_orientation()
         dims = dims[::-1]
 
         downsamples = self.get_downsample(scale_level)
 
-        out: dict[Dimension, np.ndarray] = dict()
+        out: Dict[Dimension, np.ndarray] = dict()
         for d in dims:
             c = np.arange(self.dimension[d], dtype=float)
             c *= self.resolution[d]

--- a/pymaid/neuron_label.py
+++ b/pymaid/neuron_label.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from functools import cache
-from typing import Optional, Union
+from typing import Optional, Union, List, Tuple
 import re
 
 import networkx as nx
@@ -38,7 +38,7 @@ class ThinNeuron:
         self,
         skeleton_id: Optional[int] = None,
         name: Optional[str] = None,
-        annotations: Optional[list[str]] = None,
+        annotations: Optional[List[str]] = None,
         remote_instance: Optional[CatmaidInstance] = None,
     ) -> None:
         """
@@ -51,7 +51,7 @@ class ThinNeuron:
             If None, determined from name.
         name : Optional[str], optional
             If None, determined from skeleton ID.
-        annotations : Optional[list[str]], optional
+        annotations : Optional[List[str]], optional
             If None, determined from skeleton ID or name.
         remote_instance : Optional[CatmaidInstance], optional
             If None, uses global instance.
@@ -90,7 +90,7 @@ class ThinNeuron:
         return self._name
 
     @property
-    def annotations(self) -> list[str]:
+    def annotations(self) -> List[str]:
         if self._annotations is None:
             skid = self.skeleton_id
             skid_to_anns = pymaid.get_annotations(skid)
@@ -155,8 +155,8 @@ class Annotations(LabelComponent):
         super().__init__()
 
     def _filter_by_author(
-        self, annotations: list[str], remote_instance: CatmaidInstance
-    ) -> list[str]:
+        self, annotations: List[str], remote_instance: CatmaidInstance
+    ) -> List[str]:
         if self.annotator_name is None or not annotations:
             return annotations
 
@@ -166,8 +166,8 @@ class Annotations(LabelComponent):
         return [a for a in annotations if a in allowed]
 
     def _filter_by_annotation(
-        self, annotations: list[str], remote_instance: CatmaidInstance
-    ) -> list[str]:
+        self, annotations: List[str], remote_instance: CatmaidInstance
+    ) -> List[str]:
         if self.annotated_with is None or not annotations:
             return annotations
 
@@ -193,7 +193,7 @@ def dedup_whitespace(s: str):
 @cache
 def parse_components(
     fmt: str,
-) -> tuple[list[str], list[tuple[str, int, Optional[str]]]]:
+) -> Tuple[List[str], List[Tuple[str, int, Optional[str]]]]:
     joiners = []
     components = []
     last_end = 0
@@ -264,7 +264,7 @@ class NeuronLabeller:
     """Class for calculating neurons' labels, as used in the CATMAID frontend."""
     def __init__(
         self,
-        components: Optional[list[LabelComponent]] = None,
+        components: Optional[List[LabelComponent]] = None,
         fmt="%0",
         trim_empty=True,
         remove_neighboring_duplicates=True,
@@ -273,7 +273,7 @@ class NeuronLabeller:
 
         Parameters
         ----------
-        components : list[LabelComponent], optional
+        components : List[LabelComponent], optional
             The label components as used in CATMAID's user settings.
             See `SkeletonId`, `NeuronName`, and `Annotations`.
             First component should be ``SkeletonId()`` for compatibility with CATMAID.

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -1,11 +1,11 @@
-"""Access to image data as xarray.DataArrays.
+"""Access to image data as ``xarray.DataArray``s.
 
 CATMAID's image source conventions are documented here
 https://catmaid.readthedocs.io/en/stable/tile_sources.html
 """
 from __future__ import annotations
 from io import BytesIO
-from typing import Any, Callable, Literal, Optional, Sequence, Type, Union, Dict
+from typing import Any, Literal, Optional, Sequence, Type, Union, Dict
 from abc import ABC
 import sys
 
@@ -282,9 +282,14 @@ class Stack:
 
     HTTP requests to fetch stack data are often configured
     differently for different stack mirrors and tile source types.
-    For most non-public mirrors, you will need to define a function
-    which creats an object to make these requests:
+    For most non-public mirrors, you will need to set the object to make these requests:
     see the ``my_stack.set_mirror_session()`` method.
+
+    See the ``my_stack.get_scale()`` method for getting an
+    `xarray.DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html#xarray.DataArray>`_
+    representing that scale level.
+    This can be queried in stack/ voxel or project/ world coordinates,
+    efficiently sliced and transposed etc..
     """
     def __init__(
         self,
@@ -412,7 +417,7 @@ class Stack:
     def get_scale(
         self, scale_level: int, mirror_id: Optional[int] = None
     ) -> xr.DataArray:
-        """Get an xarray.DataArray representing th given scale level.
+        """Get an xarray.DataArray representing the given scale level.
 
         Note that depending on the metadata available,
         missing scale levels may throw different errors.

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -35,7 +35,7 @@ try:
 except ImportError as e:
     raise ImportError(
         'Optional dependencies for stack viewing are not available. '
-        'Make sure the appropriate extra is installed: `pip install navis[stacks]`. '
+        'Make sure the appropriate extra is installed: `pip install pymaid[stack]`. '
         f'Original error: "{str(e)}"'
     )
 

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -270,6 +270,12 @@ class Stack:
     This class can, for certain stack mirror types,
     allow access to individual scale levels as arrays
     which can be queried in voxel or world coordinates.
+
+    HTTP requests to fetch stack data are often configured
+    differently for different stack mirrors and tile source types.
+    For most non-public mirrors, you will need to define a function
+    which creats an object to make these requests:
+    see the ``my_stack.set_mirror_session_factory()`` method.
     """
     def __init__(
         self,
@@ -434,12 +440,12 @@ class Stack:
 
         if mirror_info.tile_source_type in tile_stores:
             store_class = tile_stores[mirror_info.tile_source_type]
-            fac = self._get_session_factory(
+            session = self._get_session_factory(
                 mirror_info.id,
                 requests.Session,
-            )
+            )()
             store = store_class(
-                self.stack_info, mirror_info, scale_level, fac()
+                self.stack_info, mirror_info, scale_level, session
             )
             return store.to_xarray()
         elif mirror_info.tile_source_type == 11:

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -29,7 +29,7 @@ HALF_PX = 0.5
 ENDIAN = "<" if sys.byteorder == "little" else ">"
 
 
-def select_cli(prompt: str, options: dict[int, str]) -> Optional[int]:
+def select_cli(prompt: str, options: Dict[int, str]) -> Optional[int]:
     out = None
     print(prompt)
     for k, v in sorted(options.items()):
@@ -52,7 +52,7 @@ def select_cli(prompt: str, options: dict[int, str]) -> Optional[int]:
 
 
 def to_array(
-    coord: Union[dict[Dimension, Any], ArrayLike],
+    coord: Union[Dict[Dimension, Any], ArrayLike],
     dtype: DTypeLike = np.float64,
     order: Sequence[Dimension] = ("z", "y", "x"),
 ) -> np.ndarray:
@@ -232,7 +232,7 @@ class TileStore5(JpegStore):
 #         return s
 
 
-tile_stores: dict[int, Type[JpegStore]] = {
+tile_stores: Dict[int, Type[JpegStore]] = {
     t.tile_source_type: t
     for t in [
         TileStore1,

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+from io import BytesIO
+from typing import Literal, Optional, Sequence, Type, TypeVar, Generic, TypedDict, Union
+import numpy as np
+from abc import ABC
+from numpy.typing import DTypeLike, ArrayLike
+import zarr
+from pydantic import BaseModel
+from pydantic.tools import parse_obj_as
+from dask import array as da
+from . import utils
+from zarr.storage import BaseStore
+import json
+import sys
+import requests
+import imageio.v3 as iio
+
+Dimension = Literal["x", "y", "z"]
+Orientation = Literal["xy", "xz", "zy"]
+HALF_PX = 0.5
+ENDIAN = "<" if sys.byteorder == "little" else ">"
+
+
+class MirrorInfo(BaseModel):
+    id: int
+    title: str
+    image_base: str
+    tile_width: int
+    tile_height: int
+    tile_source_type: int
+    file_extension: str
+    position: int
+
+
+N = TypeVar("N", int, float)
+
+
+class Coord(TypedDict, Generic[N]):
+    x: N
+    y: N
+    z: N
+
+
+class StackInfo(BaseModel):
+    sid: int
+    pid: int
+    ptitle: str
+    stitle: str
+    downsample_factors: list[Coord[float]]
+    num_zoom_levels: int
+    translation: Coord[float]
+    resolution: Coord[float]
+    dimension: Coord[int]
+    comment: str
+    description: str
+    metadata: str
+    broken_slices: dict[int, int]
+    mirrors: list[MirrorInfo]
+    orientation: Orientation
+    attribution: str
+    canary_location: Coord[int]
+    placeholder_colour: dict[str, float]  # actually {r g b a}
+
+
+def to_array(
+    coord: Union[Coord[N], ArrayLike],
+    dtype: DTypeLike = np.float64,
+    order: Sequence[Dimension] = ("z", "y", "x"),
+) -> np.ndarray:
+    if isinstance(coord, dict):
+        coord = [coord[d] for d in order]
+    return np.asarray(coord, dtype=dtype)
+
+
+class TileStore(BaseStore, ABC):
+    """
+    Must include instance variable 'fmt',
+    which is a format string with variables:
+    image_base, zoom_level, file_extension, row, col, slice_idx
+    """
+    tile_source_type: int
+    fmt: str
+    _writeable = False
+    _erasable = False
+    _listable = False
+
+    def __init__(
+        self,
+        stack_info: StackInfo,
+        mirror_info: MirrorInfo,
+        zoom_level: int,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        if mirror_info.tile_source_type != self.tile_source_type:
+            raise ValueError("Mismatched tile source type")
+        self.stack_info = stack_info
+        self.mirror_info = mirror_info
+        self.zoom_level = zoom_level
+
+        if session is None:
+            cm = utils._eval_remote_instance(None)
+            self.session = cm._session
+        else:
+            self.session = session
+
+        order = full_orientation[self.stack_info.orientation]
+        self.metadata_payload = json.dumps(
+            {
+                "zarr_format": 2,
+                "shape": to_array(stack_info.dimension, order, int).tolist(),
+                "chunks": [mirror_info.tile_width, mirror_info.tile_height, 1],
+                "dtype": ENDIAN + "u1",
+                "compressor": None,
+                "fill_value": 0,
+                "order": "C",
+                "filters": None,
+                "dimension_separator": ".",
+            }
+        ).encode()
+
+        self.empty = np.zeros(
+            (
+                self.mirror_info.tile_width,
+                self.mirror_info.tile_height,
+                1,
+            ),
+            "uint8",
+        ).tobytes()
+
+    def _format_url(self, row: int, col: int, slice_idx: int) -> str:
+        return self.fmt.format(
+            zoom_level=self.zoom_level,
+            slice_idx=slice_idx,
+            row=row,
+            col=col,
+            file_extension=self.mirror_info.file_extension,
+        )
+
+    def __getitem__(self, key):
+        last = key.split("/")[-1]
+        if last == ".zarray":
+            return self.metadata_payload
+        # todo: check order
+        slice_idx, col, row = (int(i) for i in last.split("."))
+        url = self._format_url(row, col, slice_idx)
+        response = self.session.get(url)
+        if response.status_code == 404:
+            return self.empty
+        response.raise_for_status()
+        arr = iio.imread(
+            BytesIO(response.content),
+            extension=self.mirror_info.file_extension,
+            mode="L",
+        )
+        return arr.tobytes()
+
+    def to_array(self) -> zarr.Array:
+        return zarr.open_array(self, "r")
+
+    def to_dask(self) -> da.Array:
+        return da.from_zarr(self.to_array())
+
+
+class TileStore1(TileStore):
+    tile_source_type = 1
+    fmt = "{image_base}{slice_idx}/{row}_{col}_{zoom_level}.{file_extension}"
+
+
+class TileStore4(TileStore):
+    tile_source_type = 4
+    fmt = "{image_base}{slice_idx}/{zoom_level}/{row}_{col}.{file_extension}"
+
+
+class TileStore5(TileStore):
+    tile_source_type = 5
+    fmt = "{image_base}{zoom_level}/{slice_idx}/{row}/{col}.{file_extension}"
+
+
+tile_stores: dict[int, Type[TileStore]] = {
+    t.tile_source_type: t for t in [TileStore1, TileStore4, TileStore5]
+}
+
+
+class Stack:
+    def __init__(self, stack_info: StackInfo, mirror_id: Optional[int] = None):
+        self.stack_info = stack_info
+        self.mirror_info: Optional[MirrorInfo] = None
+
+        if mirror_id is not None:
+            self.set_mirror(mirror_id)
+
+    @classmethod
+    def from_catmaid(
+        cls, stack_id: int, mirror_id: Optional[int] = None, remote_instance=None
+    ):
+        cm = utils._eval_remote_instance(remote_instance)
+        info = cm.make_url("stack", stack_id, "info")
+        sinfo = parse_obj_as(StackInfo, info)
+        return cls(sinfo, mirror_id)
+
+    def _get_mirror_info(self, mirror_id: Optional[int] = None) -> MirrorInfo:
+        if mirror_id is None:
+            if self.mirror_info is None:
+                raise ValueError("No default mirror ID set")
+            return self.mirror_info
+        for mirror in self.stack_info.mirrors:
+            if mirror.id == mirror_id:
+                return mirror
+        raise ValueError(
+            f"Mirror ID {mirror_id} not found for stack {self.stack_info.sid}"
+        )
+
+    def set_mirror(self, mirror_id: int):
+        self.mirror_id = self._get_mirror_info(mirror_id)
+
+    def _res_for_scale(self, scale_level: int) -> np.ndarray:
+        return to_array(self.stack_info.resolution) * to_array(
+            self.stack_info.downsample_factors[scale_level]
+        )
+
+    def _from_array(self, arr, scale_level: int) -> ImageVolume:
+        return ImageVolume(
+            arr,
+            self.stack_info.translation,
+            self._res_for_scale(scale_level),
+            self.stack_info.orientation,
+        )
+
+    def get_scale(
+        self, scale_level: int, mirror_id: Optional[int] = None
+    ) -> ImageVolume:
+        mirror_info = self._get_mirror_info(mirror_id)
+        if scale_level > self.stack_info.num_zoom_levels:
+            raise ValueError(
+                f"Scale level {scale_level} does not exist "
+                f"for stack {self.stack_info.sid} "
+                f"with {self.stack_info.num_zoom_levels} stack levels"
+            )
+
+        if mirror_info.tile_source_type in tile_stores:
+            store_class = tile_stores[mirror_info.tile_source_type]
+            store = store_class(self.stack_info, mirror_info, scale_level, None)
+            return self._from_array(store.to_dask(), scale_level)
+        elif mirror_info.tile_source_type == 11:
+            formatted = mirror_info.image_base.replace(
+                "%SCALE_DATASET%", f"s{scale_level}"
+            )
+            *components, transpose_str = formatted.split("/")
+            transpose = [int(t) for t in transpose_str.split("_")]
+
+            store = zarr.N5FSStore("/".join(components))
+            arr = zarr.open_array(store, "r")
+            darr = da.from_zarr(arr).transpose(transpose)
+            return self._from_array(darr, scale_level)
+
+        raise NotImplementedError(
+            f"Tile source type {mirror_info.tile_source_type} not implemented"
+        )
+
+
+full_orientation: dict[Orientation, Sequence[Dimension]] = {
+    "xy": "xyz",
+    "xz": "xzy",
+    "zy": "zyx",
+}
+
+
+class ImageVolume:
+    def __init__(self, array, offset, resolution, orientation: Orientation):
+        self.array = array
+        self.offset = offset
+        self.resolution = resolution
+        self.offset = to_array(offset, dtype="float64")
+        self.resolution = to_array(resolution, dtype="float64")
+        self.orientation = orientation
+
+    @property
+    def full_orientation(self):
+        return full_orientation[self.orientation]
+
+    @property
+    def offset_oriented(self):
+        return to_array(self.offset, "float64", self.full_orientation)
+
+    @property
+    def resolution_oriented(self):
+        return to_array(self.resolution, "float64", self.full_orientation)
+
+    def __getitem__(self, selection):
+        return self.array.__getitem__(selection)
+
+    def get_roi(
+        self, offset: Coord[float], shape: Coord[float]
+    ) -> tuple[Coord[float], np.ndarray]:
+        order = self.full_orientation
+        offset_o = to_array(offset, order=order)
+        shape_o = to_array(shape, order=order)
+        mins = (offset_o / self.resolution - self.offset - HALF_PX).astype("uint64")
+        maxes = np.ceil(
+            (offset_o + shape_o) / self.resolution - self.offset - HALF_PX
+        ).astype("uint64")
+        slicing = tuple(slice(mi, ma) for mi, ma in zip(mins, maxes))
+        # todo: finalise orientation
+        actual_offset = Coord(
+            **{
+                d: m
+                for d, m in zip(
+                    order, mins * self.resolution_oriented + self.offset_oriented
+                )
+            }
+        )
+        return actual_offset, self[slicing]

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -264,6 +264,8 @@ tile_stores: Dict[int, Type[ImageIoStore]] = {
 source_client_types = {k: (requests.Session,) for k in tile_stores}
 source_client_types[11] = (aiohttp.ClientSession,)
 
+Client = Union[requests.Session, aiohttp.ClientSession]
+
 
 def select_stack(remote_instance=None) -> Optional[int]:
     """"""
@@ -311,7 +313,7 @@ class Stack:
             self.set_mirror(mirror)
 
     def set_mirror_session(
-        self, mirror: Union[int, str, None], session,
+        self, mirror: Union[int, str, None], session: Client,
     ):
         """Set functions which construct the session for fetching image data, per mirror.
 
@@ -327,7 +329,7 @@ class Stack:
         ----------
         mirror : Union[int, str, None]
             Mirror, as integer ID, string name, or None to use the one defined on the class.
-        session : Callable[[], Any]
+        session : Union[requests.Session, aiohttp.ClientSession]
             HTTP session of the appropriate type.
             For example, to re-use the ``requests.Session`` from the
             global ``CatmaidInstance`` for mirror with ID 1, use

--- a/pymaid/stack.py
+++ b/pymaid/stack.py
@@ -4,6 +4,7 @@ CATMAID's image source conventions are documented here
 https://catmaid.readthedocs.io/en/stable/tile_sources.html
 """
 from __future__ import annotations
+from functools import wraps
 from io import BytesIO
 from typing import Any, Literal, Optional, Sequence, Type, Union, Dict
 from abc import ABC
@@ -45,11 +46,18 @@ HALF_PX = 0.5
 ENDIAN = "<" if sys.byteorder == "little" else ">"
 
 
+@wraps(print)
+def eprint(*args, **kwargs):
+    """Thin wrapper around ``print`` which defaults to stderr"""
+    kwargs.setdefault("file", sys.stderr)
+    return print(*args, **kwargs)
+
+
 def select_cli(prompt: str, options: Dict[int, str]) -> Optional[int]:
     out = None
-    print(prompt)
+    eprint(prompt)
     for k, v in sorted(options.items()):
-        print(f"\t{k}.\t{v}")
+        eprint(f"\t{k}.\t{v}")
     p = "Type number and press enter (empty to cancel): "
     while out is None:
         result_str = input(p).strip()
@@ -58,10 +66,10 @@ def select_cli(prompt: str, options: Dict[int, str]) -> Optional[int]:
         try:
             result = int(result_str)
         except ValueError:
-            print("Not an integer, try again")
+            eprint("Not an integer, try again")
             continue
         if result not in options:
-            print("Not a valid option, try again")
+            eprint("Not a valid option, try again")
             continue
         out = result
     return out
@@ -397,7 +405,7 @@ class Stack:
             if m.tile_source_type in source_client_types
         }
         if not options:
-            print("No mirrors with supported tile source type")
+            eprint("No mirrors with supported tile source type")
             return
 
         result = select_cli(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "extreqs"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ psutil>=5.4.3
 #extra: extras
 fuzzywuzzy[speedup]~=0.17.0
 ujson~=1.35
+zarr
 
 # diskcache>=4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ tqdm>=4.50.0
 psutil>=5.4.3
 
 #extra: extras
-fuzzywuzzy[speedup]~=0.17.0
 ujson~=1.35
 
 #extra: stack

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,12 @@ psutil>=5.4.3
 #extra: extras
 fuzzywuzzy[speedup]~=0.17.0
 ujson~=1.35
+
+#extra: stacks
 zarr
-pydantic
+fsspec[http]
+pydantic>=2
+xarray[parallel]
 imageio
 
 # diskcache>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ psutil>=5.4.3
 fuzzywuzzy[speedup]~=0.17.0
 ujson~=1.35
 zarr
+pydantic
+imageio
 
 # diskcache>=4.0.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psutil>=5.4.3
 fuzzywuzzy[speedup]~=0.17.0
 ujson~=1.35
 
-#extra: stacks
+#extra: stack
 zarr
 fsspec[http]
 xarray[parallel]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ ujson~=1.35
 #extra: stacks
 zarr
 fsspec[http]
-pydantic>=2
 xarray[parallel]
 imageio
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,11 @@ scipy>=1.3.0
 six>=1.11.0
 tqdm>=4.50.0
 psutil>=5.4.3
+
+#extra: extras
+fuzzywuzzy[speedup]~=0.17.0
+ujson~=1.35
+
 # diskcache>=4.0.0
 
 # Below are optional dependencies

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import itertools
 from setuptools import setup, find_packages
 import re
 from pathlib import Path
@@ -15,6 +16,7 @@ else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
 
 install_requires, extras_require = parse_requirement_files(Path("requirements.txt"))
+extras_require["all"] = list(set(itertools.chain.from_iterable(extras_require.values())))
 
 setup(
     name='python-catmaid',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
 import re
+from pathlib import Path
+
+from extreqs import parse_requirement_files
 
 
 VERSIONFILE = "pymaid/__init__.py"
@@ -11,9 +14,7 @@ if mo:
 else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-    requirements = [l for l in requirements if not l.startswith('#')]
+install_requires, extras_require = parse_requirement_files(Path("requirements.txt"))
 
 setup(
     name='python-catmaid',
@@ -45,9 +46,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
     ],
-    install_requires=requirements,
-    extras_require={'extras': ['fuzzywuzzy[speedup]~=0.17.0',
-                               'ujson~=1.35']},
+    install_requires=install_requires,
+    extras_require=extras_require,
     python_requires='>=3.9',
     zip_safe=False
 )


### PR DESCRIPTION
Introduces a `Stack` class which loads stack and mirror info from CATMAID. That has a `get_scale` method which returns an `xarray.DataArray` representing that scale level, which wraps a dask array wrapping a zarr array. Depending on the mirror info, the zarr array pulls either from an N5 store, or one of a few custom zarr store shims implementing a few of our more common tile source types (JPEG stacks, for now, but H2N5 should be fairly low-hanging fruit as well). `xarray` allows us to pull data in voxel or world space.

The `Stack` can be created simply from a catmaid client instance and stack ID or title (or by selection with a CLI). By default the JPEG tile sources re-use the session from that client instance (so that auth headers are re-used).

Using dask arrays means we can have concurrent downloads and also do things like lazy transposes, which means we can use CATMAID's orientations. However, there is quite a lot of complexity in the interactions between N5, Zarr, and CATMAID orientations, which needs a fair bit of testing.

To do

- [x] Literally any testing at all :grimacing: 
- [x] HTTP auth for tile stores
- [x] HTTP auth for N5FSStore
- [ ] Make sure the orientations all work out correctly
- [x] Docs
- [ ] Maybe implement some more tile sources
